### PR TITLE
Move instance actor key position in env.example and disable dev icons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ FEDERATION_DOMAIN=localhost:3000
 FEDERATION_HANDLE_DOMAIN=localhost:3000
 FEDERATION_PROTOCOL=http
 
+# Generate a new key for production using `yarn generate-key` and paste it here
+INSTANCE_ACTOR_KEY=''
+
 # ======================
 # Frontend Configuration
 # ======================
@@ -87,8 +90,3 @@ MAX_FILE_SIZE_MB=200
 # DOMAIN=cosmosli.de
 # FEDERATION_DOMAIN=api.cosmosli.de
 # FEDERATION_PROTOCOL=https
-
-# ======================
-# INSTANCE_ACTOR_KEY
-# ======================
-INSTANCE_ACTOR_KEY='' # Generate a new key for production using `yarn generate-keys`

--- a/packages/backend/src/modules/federation/handlers/actor.handler.ts
+++ b/packages/backend/src/modules/federation/handlers/actor.handler.ts
@@ -538,8 +538,10 @@ export class ActorHandler {
           }),
           following: ctx.getFollowingUri(identifier),
           followers: ctx.getFollowersUri(identifier),
-          icon: new Image({
-            url: new URL('/favicon.svg', ctx.canonicalOrigin),
+          ...(process.env.NODE_ENV !== 'development' && {
+            icon: new Image({
+              url: new URL('/favicon.svg', ctx.canonicalOrigin),
+            }),
           }),
           publicKey: keys[0].cryptographicKey,
           assertionMethods: keys.map((pair) => pair.multikey),
@@ -555,8 +557,12 @@ export class ActorHandler {
 
     // Create Fedify actor data using context methods for proper URI generation
     const actorData = toAPPersonObject(ctx, actor);
-    // Add optional icon if available
-    if (actor.icon && actor.icon.url) {
+    // Add optional icon if available (skip in development)
+    if (
+      process.env.NODE_ENV !== 'development' &&
+      actor.icon &&
+      actor.icon.url
+    ) {
       actorData.icon = new Image({
         url: new URL(actor.icon.url),
         mediaType: actor.icon.mediaType,
@@ -576,7 +582,9 @@ export class ActorHandler {
         endpoints: new Endpoints({
           sharedInbox: ctx.getInboxUri(),
         }),
-        icon: new URL('/favicon.svg', ctx.canonicalOrigin),
+        ...(process.env.NODE_ENV !== 'development' && {
+          icon: new URL('/favicon.svg', ctx.canonicalOrigin),
+        }),
       });
     } else if (actor.type === 'Application' || actor.type === 'Service') {
       result = new Application(actorData);


### PR DESCRIPTION
## Summary
On Development Env, Just Don't return icon because of user's icon profile doesn't exist. 
and Just Simple moving `INSTANCE_ACTOR_KEY` position. 

## Changes
- Exclude `icon` field when sending activities in development mode
- Reorder variables in `.env.example` (moved `INSTANCE_ACTOR_KEY`)

## Test 
On `activitypub.academy`, it was working(`follow`, etc..). 