### PR TITLE
Fix presentation note HTML link and actor icon handling

### DIFF
--- a/packages/backend/src/modules/federation/handlers/actor.handler.ts
+++ b/packages/backend/src/modules/federation/handlers/actor.handler.ts
@@ -559,24 +559,16 @@ export class ActorHandler {
     // toAPPersonObject now includes the icon automatically
     const actorData = toAPPersonObject(ctx, actor);
 
-    // Add optional icon if available (skip in development)
-    if (
-      process.env.NODE_ENV !== 'development' &&
-      actor.icon &&
-      actor.icon.url
-    ) {
-      actorData.icon = new Image({
-        url: new URL(actor.icon.url),
-        mediaType: actor.icon.mediaType,
-      });
-    }
-
-    // Add optional icon if available
-    if (actor.icon && actor.icon.url) {
-      actorData.icon = new Image({
-        url: new URL(actor.icon.url),
-        mediaType: actor.icon.mediaType,
-      });
+    // Add icon only if it exists and is valid
+    if (actor.icon && typeof actor.icon.url === 'string' && actor.icon.url !== '') {
+      try {
+        actorData.icon = new Image({
+          url: new URL(actor.icon.url),
+          mediaType: actor.icon.mediaType,
+        });
+      } catch (e) {
+        // Invalid URL, skip icon
+      }
     }
 
     // Return the appropriate Fedify Actor type

--- a/packages/backend/src/modules/presentation/presentation.service.ts
+++ b/packages/backend/src/modules/presentation/presentation.service.ts
@@ -120,7 +120,7 @@ export class PresentationService {
 
     if (actor) {
       // Create Note with presentation
-      const noteContent = `${title} ${presentationUrl}`;
+      const noteContent = `${title}<br><a href="${presentationUrl}">Detail View</a>`;
       const note = await this.timelineService.createNote(actor, {
         content: noteContent,
         visibility: 'public',


### PR DESCRIPTION
## Summary
Fix the Style when User Create a presentation.

Refer the below images:
<img width="862" height="315" alt="스크린샷 2025-11-05 오후 5 32 11" src="https://github.com/user-attachments/assets/8efcdab4-fe74-48bd-890c-185c17803062" />

## Changes
- Fix Note Format
- if icon is invalid, don't use it.

## Testing
View : ActivityPub.Academy and Hackers.pub
