### PR TITLE
add Upload link to navigation header

### DIFF
--- a/packages/frontend/app/upload/page.tsx
+++ b/packages/frontend/app/upload/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { uploadApi } from '@/lib/api';
-import NavigationHeader from '@/components/NavigationHeader';
 import CosmoPage from '@/components/CosmoPage';
 
 export default function UploadPage() {

--- a/packages/frontend/components/NavigationHeader.tsx
+++ b/packages/frontend/components/NavigationHeader.tsx
@@ -21,6 +21,7 @@ export default function NavigationHeader() {
       { href: '/timeline/public', label: 'Public', icon: '🌍', requiresAuth: false },
       { href: '/search', label: 'Search', icon: '🔍', requiresAuth: true },
       { href: '/presentations', label: 'Presentations', icon: '📄', requiresAuth: true },
+      { href: '/upload', label: 'Upload', icon: '📤', requiresAuth: true },
       { href: '/settings', label: 'Settings', icon: '⚙️', requiresAuth: true },
     ]
 


### PR DESCRIPTION
## Summary
Add /upload link to navigation header(upper menu)

## Changes
- Add /upload link to navigation header(upper menu)

## Testing
It works on my machine. 

screenshot:
<img width="962" height="613" alt="스크린샷 2025-11-08 오전 11 51 36" src="https://github.com/user-attachments/assets/44bd0531-04d3-49db-b789-597288645073" />
