### PR TITLE
bugfix renoted info in public timeline posts

### DIFF
--- a/packages/backend/src/modules/microblogging/microblogging.controller.ts
+++ b/packages/backend/src/modules/microblogging/microblogging.controller.ts
@@ -214,14 +214,42 @@ export class MicrobloggingController {
     const notes = await this.noteService.getPublicTimelineNotes({ limit });
 
     // Transform notes to include username format the frontend expects
-    const transformedNotes = notes.map((note) => ({
-      ...note,
-      author: {
-        ...note.author,
-        username: note.author?.preferredUsername,
-        displayName: note.author?.name,
-      },
-    }));
+    const transformedNotes = notes.map((note) => {
+      if (note.sharedNoteId && note.sharedNote) {
+        return {
+          ...note,
+          isShared: true,
+          sharedBy: {
+            ...note.author,
+            username: note.author?.preferredUsername,
+            displayName: note.author?.name,
+          },
+          sharedNote: {
+            ...note.sharedNote,
+            author: {
+              ...note.sharedNote.author,
+              username: note.sharedNote.author?.preferredUsername,
+              displayName: note.sharedNote.author?.name,
+            },
+          },
+          author: {
+            ...note.author,
+            username: note.author?.preferredUsername,
+            displayName: note.author?.name,
+          },
+        };
+      } else {
+        return {
+          ...note,
+          isShared: false,
+          author: {
+            ...note.author,
+            username: note.author?.preferredUsername,
+            displayName: note.author?.name,
+          },
+        };
+      }
+    });
 
     return {
       notes: transformedNotes || [],

--- a/packages/backend/src/modules/microblogging/services/note.service.ts
+++ b/packages/backend/src/modules/microblogging/services/note.service.ts
@@ -58,7 +58,7 @@ export class NoteService {
     const offset = parseInt(cursor || '0');
 
     const notes = await this.noteRepository.find({
-      relations: ['author'],
+      relations: ['author', 'sharedNote', 'sharedNote.author'],
       order: {
         createdAt: 'DESC',
       },

--- a/packages/frontend/components/NoteCard.tsx
+++ b/packages/frontend/components/NoteCard.tsx
@@ -143,7 +143,7 @@ export default function NoteCard({
         <div className="flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400 mb-2 ml-12">
           <span className="text-green-600 dark:text-green-400">🔁</span>
           <a href={sharerProfilePath} className="hover:underline">
-            {sharerDisplayName} reblogged
+            {sharerDisplayName} 님이 공유
           </a>
         </div>
       )}


### PR DESCRIPTION
## Summary
Show renoted (shared) info and original author in public timeline posts, 
so the frontend can display "share" UI for shared notes.

## Changes
- Updated GET /timeline/public endpoint
- Updated word(`reblogged` to `님이 공유`). 

## Preview 
<img width="549" height="495" alt="스크린샷 2025-11-12 오후 2 32 33" src="https://github.com/user-attachments/assets/e382ba4e-9cb7-404a-8eb6-ff2fc53edd41" />

## Note 
- Like the public timeline, consistency must be maintained between returning multiple notes and returning a single note. 
To be addressed in a future update.
