### PR TITLE
implement copy url button on presentation page

### DIFF
--- a/packages/frontend/app/presentations/page.tsx
+++ b/packages/frontend/app/presentations/page.tsx
@@ -21,7 +21,7 @@ function PresentationsPageContent() {
   const [presentations, setPresentations] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<{ show: boolean; message: string; color?: string }>({ show: false, message: '', color: undefined });
-  const toastTimeout = useRef<NodeJS.Timeout | null>(null);
+  const toastTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!authLoading) {
@@ -77,6 +77,7 @@ function PresentationsPageContent() {
         className={`fixed z-50 left-1/2 -translate-x-1/2 bottom-8 px-6 py-3 rounded shadow-lg text-white text-sm font-medium transition-opacity duration-500 ${toast.color || 'bg-green-600'} ${toast.show ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
         style={{ minWidth: 180 }}
         aria-live="polite"
+        role="status"
       >
         {toast.message}
       </div>


### PR DESCRIPTION
## Summary
This code changes adds a "Copy URL" button to the Presentation Page for easy sharing. 
The button copies the presentation URL to the clipboard, allowing users to quickly share presentations by pasting the link. This is a frontend-only change.

## Changes
- Implement `Copy URL` button. 
 - For this, I have simple toast message for show it.

## Testing
It works on my machine.

# Screenshot for this:
## my presentations page (`/presentations`)
<img width="1289" height="570" alt="스크린샷 2025-11-21 오전 11 09 00" src="https://github.com/user-attachments/assets/05378b2a-c4fc-4e5f-b92c-274cf744ea9a" />

## Click Event(When User click this button)
<img width="1275" height="676" alt="스크린샷 2025-11-21 오전 11 10 00" src="https://github.com/user-attachments/assets/0031ba49-27dd-4605-994a-3270537bd1b6" />
(Note: This screenshot is outdated and shows the toast message in Korean. The message has since been updated to English.)

## Notes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast notifications added to the page layout for user feedback.
  * Notifications auto-dismiss after a short period.
  * Copy URL button added to each presentation item.
  * Copying a presentation URL shows immediate feedback: success (violet) or error (red).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->